### PR TITLE
Add detailed usage examples and JSDoc for transactWriteItems and transactGetItems

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -284,6 +284,62 @@ const id4 = await getAscendingId({
 console.log(id4); // "00000010"
 ```
 
+### TransactWriteItems
+
+```ts
+import { transactWriteItems } from "@moicky/dynamodb";
+
+// Perform a TransactWriteItems operation
+const response = await transactWriteItems([
+  {
+    Put: {
+      item: {
+        PK: "User/1",
+        SK: "Book/1",
+        title: "The Great Gatsby",
+        author: "F. Scott Fitzgerald",
+        released: 1925,
+      },
+    },
+  },
+  {
+    Update: {
+      key: { PK: "User/1", SK: "Book/1" },
+      updateData: { title: "The Great Gatsby - Updated" },
+    },
+  },
+  {
+    Delete: {
+      key: { PK: "User/1", SK: "Book/1" },
+    },
+  },
+  {
+    ConditionCheck: {
+      key: { PK: "User/1", SK: "Book/1" },
+      ConditionExpression: "#title = :title",
+      conditionData: { title: "The Great Gatsby" },
+    },
+  },
+]);
+
+console.log(response);
+```
+
+### TransactGetItems
+
+```ts
+import { transactGetItems } from "@moicky/dynamodb";
+
+// Perform a TransactGetItems operation
+const items = await transactGetItems([
+  { key: { PK: "User/1", SK: "Book/1" } },
+  { key: { PK: "User/1", SK: "Book/2" } },
+  { key: { PK: "User/1", SK: "Book/3" } },
+]);
+
+console.log(items);
+```
+
 ## Configuring global defaults
 
 Global defaults can be configured using the `initDefaults` function. This allows to provide but still override every property of the `args` parameter.

--- a/src/operations/transactWriteItems.ts
+++ b/src/operations/transactWriteItems.ts
@@ -56,6 +56,50 @@ type ResponseItem = Pick<ItemCollectionMetrics, "SizeEstimateRangeGB"> & {
   Key: Record<string, any>;
 };
 
+/**
+ * Performs a TransactWriteItems operation against DynamoDB. This allows you to perform multiple write operations in a single transaction.
+ * @param transactItems - Array of items to transact. Each item can be a Put, Update, Delete, or ConditionCheck operation.
+ * @param args - The additional arguments to override or specify for {@link TransactWriteItemsCommandInput}
+ * @returns A promise that resolves to a record of response items
+ *
+ * @example
+ * Perform a TransactWriteItems operation
+ * ```javascript
+ * const response = await transactWriteItems([
+ *   {
+ *     Put: {
+ *       item: {
+ *         PK: "User/1",
+ *         SK: "Book/1",
+ *         title: "The Great Gatsby",
+ *         author: "F. Scott Fitzgerald",
+ *         released: 1925,
+ *       },
+ *     },
+ *   },
+ *   {
+ *     Update: {
+ *       key: { PK: "User/1", SK: "Book/1" },
+ *       updateData: { title: "The Great Gatsby - Updated" },
+ *     },
+ *   },
+ *   {
+ *     Delete: {
+ *       key: { PK: "User/1", SK: "Book/1" },
+ *     },
+ *   },
+ *   {
+ *     ConditionCheck: {
+ *       key: { PK: "User/1", SK: "Book/1" },
+ *       ConditionExpression: "#title = :title",
+ *       conditionData: { title: "The Great Gatsby" },
+ *     },
+ *   },
+ * ]);
+ *
+ * console.log(response);
+ * ```
+ */
 export async function transactWriteItems(
   transactItems: TransactItem[],
   args: TransactWriteItemsInput = {}


### PR DESCRIPTION
Fixes #4

Add detailed documentation and examples for `transactWriteItems` and `transactGetItems` in the `readme.md` and JSDoc comments in the respective TypeScript files.

* **readme.md**
  - Add detailed usage examples for `transactWriteItems`
  - Add detailed usage examples for `transactGetItems`

* **src/operations/transactWriteItems.ts**
  - Add JSDoc comments for the `transactWriteItems` function

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Moicky/dynamodb/issues/4?shareId=22db2f6e-8508-4253-bc0f-d8831c6e75af).