### PR TITLE
Fix ProjectionExpression to resolve placeholders

### DIFF
--- a/src/operations/query.ts
+++ b/src/operations/query.ts
@@ -45,6 +45,7 @@ async function _query(
         attributesToGet: [
           ...getAttributesFromExpression(keyCondition),
           ...getAttributesFromExpression(args?.FilterExpression || ""),
+          ...getAttributesFromExpression(args?.ProjectionExpression || ""),
         ],
       }),
       ...args,

--- a/test/operations/query.test.js
+++ b/test/operations/query.test.js
@@ -136,4 +136,26 @@ describe("query operations", () => {
       expect(pageResults.hasNextPage).toEqual(true);
     }
   });
+
+  it("should resolve placeholders in ProjectionExpression", async () => {
+    const items = await queryItems(
+      "#PK = :PK",
+      { PK },
+      { ProjectionExpression: "#title, #author" }
+    );
+    expect(items.length).toBeGreaterThan(0);
+    expect(items[0]).toHaveProperty("title");
+    expect(items[0]).toHaveProperty("author");
+  });
+
+  it("should resolve placeholders in ProjectionExpression without filters", async () => {
+    const items = await queryItems(
+      "#PK = :PK",
+      { PK },
+      { ProjectionExpression: "#title, #author" }
+    );
+    expect(items.length).toBeGreaterThan(0);
+    expect(items[0]).toHaveProperty("title");
+    expect(items[0]).toHaveProperty("author");
+  });
 });


### PR DESCRIPTION
Fixes #2

Update `query` function to resolve placeholders in `ProjectionExpression`.

* **src/operations/query.ts**
  - Add logic to resolve placeholders in `ProjectionExpression` by including `getAttributesFromExpression(args?.ProjectionExpression || "")` in `ExpressionAttributeNames`.

* **test/operations/query.test.js**
  - Add test to check if placeholders in `ProjectionExpression` are resolved correctly.
  - Add test to check if placeholders in `ProjectionExpression` are resolved correctly without filters.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Moicky/dynamodb/issues/2?shareId=54b17ae6-712a-4bd8-9908-41cbfb29fca0).