### PR TITLE
Update timestamps to use ISO string format

### DIFF
--- a/src/operations/put.ts
+++ b/src/operations/put.ts
@@ -55,7 +55,7 @@ export async function putItem<
   const argsWithDefaults = withDefaults(args || {}, "putItem");
 
   if (!Object.keys(item).includes("createdAt")) {
-    item = { ...item, createdAt: Date.now() };
+    item = { ...item, createdAt: new Date().toISOString(), createdAtISO: new Date().toISOString() };
   }
   const { ReturnValues, ...otherArgs } = argsWithDefaults;
 
@@ -114,12 +114,13 @@ export async function putItems(
   args = withDefaults(args, "putItems");
 
   return new Promise(async (resolve, reject) => {
-    const now = Date.now();
+    const now = new Date().toISOString();
 
     const batches = splitEvery(
       items.map((item) => ({
         ...item,
         createdAt: item?.createdAt ?? now,
+        createdAtISO: item?.createdAtISO ?? now,
       }))
     );
     const results = [];

--- a/src/operations/update.ts
+++ b/src/operations/update.ts
@@ -77,7 +77,7 @@ export async function updateItem(
   const argsWithDefaults = withDefaults(args || {}, "updateItem");
 
   if (!Object.keys(data).includes("updatedAt")) {
-    data = { ...data, updatedAt: Date.now() };
+    data = { ...data, updatedAt: new Date().toISOString(), updatedAtISO: new Date().toISOString() };
   }
 
   const valuesInCondition = getAttributesFromExpression(

--- a/test/operations/put.test.js
+++ b/test/operations/put.test.js
@@ -61,4 +61,13 @@ describe("put operations", () => {
     expect(savedItems.length).toEqual(500);
     expect(savedItems.filter((item) => item).length).toEqual(500);
   });
+
+  it("should set createdAtISO attribute correctly", async () => {
+    const newItem = generateItem("1000");
+
+    await putItem(newItem);
+
+    const savedItem = await getItem(newItem);
+    expect(savedItem.createdAtISO).toBe(new Date(savedItem.createdAt).toISOString());
+  });
 });

--- a/test/operations/update.test.js
+++ b/test/operations/update.test.js
@@ -65,4 +65,14 @@ describe("update operations", () => {
 
     expect(newItem.released).toEqual(2000);
   });
+
+  it("should set updatedAtISO attribute correctly", async () => {
+    const item = await getItem(generateItem("4"));
+    expect(item.PK).toEqual(PK);
+
+    await updateItem(item, { title: "Another New Title" });
+
+    const updatedItem = await getItem(generateItem("4"));
+    expect(updatedItem.updatedAtISO).toBe(new Date(updatedItem.updatedAt).toISOString());
+  });
 });


### PR DESCRIPTION
Related to #9

Update `createdAt` and `updatedAt` fields to use ISO String format instead of timestamp.

* Modify `src/operations/put.ts` to set `createdAt` and `createdAtISO` attributes using `new Date().toISOString()`.
* Modify `src/operations/update.ts` to set `updatedAt` and `updatedAtISO` attributes using `new Date().toISOString()`.
* Add test case in `test/operations/put.test.js` to verify `createdAtISO` attribute is set correctly.
* Add test case in `test/operations/update.test.js` to verify `updatedAtISO` attribute is set correctly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Moicky/dynamodb/pull/16?shareId=2f81be82-74f4-412f-999c-d3d4be175a98).