### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,8 @@
 name: Run tests using jest
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Moicky/dynamodb/security/code-scanning/1](https://github.com/Moicky/dynamodb/security/code-scanning/1)

In general, the fix is to explicitly restrict the `GITHUB_TOKEN` permissions for this workflow to the minimum required. Since this job only needs to read the repository contents (for `actions/checkout`) and does not appear to perform any writes via `GITHUB_TOKEN`, we can safely set `contents: read`. This can be done at the workflow root level so it applies to all jobs, including `run-tests`.

The best minimally invasive fix is to add a `permissions:` block near the top of `.github/workflows/run-tests.yml` (e.g., right after the `name:` line and before `on:`). This will ensure that all jobs in this workflow, including the one at line 17, run with a `GITHUB_TOKEN` that has only read access to repository contents. No changes are required to the existing steps, and no additional methods, imports, or definitions are necessary because this is purely a YAML configuration change.

Specifically, edit `.github/workflows/run-tests.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Run tests using jest`). No other permissions appear necessary based on the provided steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits the workflow token scope to the minimum necessary.
> 
> - Adds `permissions: contents: read` at the root of `.github/workflows/run-tests.yml`, applying least-privilege `GITHUB_TOKEN` to all jobs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2813ce23057d5174eaaa670716e519e8aa1d97e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->